### PR TITLE
Add dependencies so that examples can be run with 'uv run'

### DIFF
--- a/deploy/deploy_docker_existing_image.py
+++ b/deploy/deploy_docker_existing_image.py
@@ -1,3 +1,7 @@
+# /// script
+# dependencies = ["prefect"]
+# ///
+
 """
 Deploy a flow using an existing Docker image that contains your flow
 

--- a/deploy/deploy_docker_in_docker.py
+++ b/deploy/deploy_docker_in_docker.py
@@ -1,3 +1,7 @@
+# /// script
+# dependencies = ["prefect"]
+# ///
+
 """
 Deploy a flow in an existing Docker image from inside the image
 

--- a/deploy/deploy_many.py
+++ b/deploy/deploy_many.py
@@ -1,3 +1,7 @@
+# /// script
+# dependencies = ["prefect"]
+# ///
+
 """
 An example of discovering and deploying multiple flows from a directory.
 

--- a/deploy/source_docker.py
+++ b/deploy/source_docker.py
@@ -1,3 +1,7 @@
+# /// script
+# dependencies = ["prefect"]
+# ///
+
 """
 # Deploy a flow using Docker
 

--- a/deploy/source_github.py
+++ b/deploy/source_github.py
@@ -1,3 +1,7 @@
+# /// script
+# dependencies = ["prefect"]
+# ///
+
 """
 # Deploy a flow from a git repository
 

--- a/scripts/cross_workspace_flow_runs.py
+++ b/scripts/cross_workspace_flow_runs.py
@@ -1,3 +1,7 @@
+# /// script
+# dependencies = ["prefect"]
+# ///
+
 """
 This script lists flow run counts by state and date for all workspaces in an account.
 

--- a/scripts/extract_with_dlt.py
+++ b/scripts/extract_with_dlt.py
@@ -1,3 +1,7 @@
+# /// script
+# dependencies = ["prefect", "dlt"]
+# ///
+
 import dlt
 from dlt.sources.rest_api import rest_api_source
 from prefect.settings import PREFECT_API_KEY, PREFECT_API_URL

--- a/scripts/list_block_type_versions.py
+++ b/scripts/list_block_type_versions.py
@@ -1,3 +1,7 @@
+# /// script
+# dependencies = ["prefect"]
+# ///
+
 """
 Get the registered versions of each block type in a workspace.
 

--- a/scripts/update_deployment_concurrency_limit.py
+++ b/scripts/update_deployment_concurrency_limit.py
@@ -1,3 +1,7 @@
+# /// script
+# dependencies = ["prefect"]
+# ///
+
 """
 Update a deployment's concurrency limit via the API. This is a workaround
 for instances where Prefect 2.x is installed and models do not directly support


### PR DESCRIPTION
Extends the inline dependencies approach from https://github.com/PrefectHQ/examples/pull/2 to Python files in the `deploy/` and `scripts/` directories.