### PR TITLE
feat(infra): add example Terraform module for ECS workers

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -16,4 +16,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.9"
+      - name: Install tool dependencies
+        uses: jdx/mise-action@v2
       - uses: pre-commit/action@v3.0.1

--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,11 @@ uv.lock
 
 # vscode
 .vscode/
+
+# Local Terraform provider cache and state
+.terraform
+.terraform.lock.hcl
+terraform.tfstate
+terraform.tfstate.*.backup
+terraform.tfstate.backup
+local.tfvars

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,2 @@
+[tools]
+terraform-docs = '0.19.0'

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,2 +1,3 @@
 [tools]
-terraform-docs = '0.19.0'
+terraform = "1.11.0"
+terraform-docs = "0.19.0"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,3 +29,4 @@ repos:
   rev: v1.83.5
   hooks:
     - id: terraform_fmt
+      files: ^(infra/amazon-ecs-worker/.*)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,9 +15,7 @@ repos:
   hooks:
     - id: terraform-docs
       name: Terraform Provider Docs
-      # only run if these files are modified:
-      # - infra/
-      files: ^(infra/.*)$
+      files: ^(infra/amazon-ecs-worker/.*)$
       entry: terraform-docs
       args:
         - markdown

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,23 @@ repos:
   rev: v2.2.4
   hooks:
     - id: codespell
+- repo: local
+  hooks:
+    - id: terraform-docs
+      name: Terraform Provider Docs
+      # only run if these files are modified:
+      # - infra/
+      files: ^(infra/.*)$
+      entry: terraform-docs
+      args:
+        - markdown
+        - table
+        - infra/amazon-ecs-worker
+        - --output-file
+        - README.md
+      language: system
+      pass_filenames: false
+- repo: https://github.com/antonbabenko/pre-commit-terraform
+  rev: v1.83.5
+  hooks:
+    - id: terraform_fmt

--- a/infra/amazon-ecs-worker/README.md
+++ b/infra/amazon-ecs-worker/README.md
@@ -93,8 +93,8 @@ No modules.
 | [aws_ecs_task_definition.prefect_worker_task_definition](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
 | [aws_iam_role.prefect_worker_execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.prefect_worker_task_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy.](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.logs_allow_create_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.prefect_worker_allow_ecs_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.ssm_allow_read_prefect_api_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy_attachment.prefect_worker_ecs_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_secretsmanager_secret.prefect_api_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |

--- a/infra/amazon-ecs-worker/README.md
+++ b/infra/amazon-ecs-worker/README.md
@@ -118,21 +118,21 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_name"></a> [name](#input\_name) | Unique name for this worker deployment | `string` | n/a | yes |
-| <a name="input_prefect_account_id"></a> [prefect\_account\_id](#input\_prefect\_account\_id) | Prefect cloud account ID | `string` | n/a | yes |
-| <a name="input_prefect_api_key"></a> [prefect\_api\_key](#input\_prefect\_api\_key) | Prefect cloud API key | `string` | n/a | yes |
-| <a name="input_prefect_workspace_id"></a> [prefect\_workspace\_id](#input\_prefect\_workspace\_id) | Prefect cloud workspace ID | `string` | n/a | yes |
+| <a name="input_prefect_account_id"></a> [prefect\_account\_id](#input\_prefect\_account\_id) | Prefect Cloud account ID | `string` | n/a | yes |
+| <a name="input_prefect_api_key"></a> [prefect\_api\_key](#input\_prefect\_api\_key) | Prefect Cloud API key | `string` | n/a | yes |
+| <a name="input_prefect_workspace_id"></a> [prefect\_workspace\_id](#input\_prefect\_workspace\_id) | Prefect Cloud workspace ID | `string` | n/a | yes |
 | <a name="input_secrets_manager_recovery_in_days"></a> [secrets\_manager\_recovery\_in\_days](#input\_secrets\_manager\_recovery\_in\_days) | Deletion delay for AWS Secrets Manager upon resource destruction | `number` | `30` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID in which to create all resources | `string` | n/a | yes |
 | <a name="input_worker_cpu"></a> [worker\_cpu](#input\_worker\_cpu) | CPU units to allocate to the worker | `number` | `1024` | no |
 | <a name="input_worker_desired_count"></a> [worker\_desired\_count](#input\_worker\_desired\_count) | Number of workers to run | `number` | `1` | no |
 | <a name="input_worker_extra_pip_packages"></a> [worker\_extra\_pip\_packages](#input\_worker\_extra\_pip\_packages) | Packages to install on the worker assuming image is based on prefecthq/prefect | `string` | `"prefect-aws s3fs"` | no |
 | <a name="input_worker_image"></a> [worker\_image](#input\_worker\_image) | Container image for the worker. This could be the name of an image in a public repo or an ECR ARN | `string` | `"prefecthq/prefect:3-python3.11"` | no |
-| <a name="input_worker_log_retention_in_days"></a> [worker\_log\_retention\_in\_days](#input\_worker\_log\_retention\_in\_days) | Number of days to retain worker logs for | `number` | `30` | no |
+| <a name="input_worker_log_retention_in_days"></a> [worker\_log\_retention\_in\_days](#input\_worker\_log\_retention\_in\_days) | Number of days to retain worker logs | `number` | `30` | no |
 | <a name="input_worker_memory"></a> [worker\_memory](#input\_worker\_memory) | Memory units to allocate to the worker | `number` | `2048` | no |
-| <a name="input_worker_subnets"></a> [worker\_subnets](#input\_worker\_subnets) | Subnets to place the worker in | `list(string)` | n/a | yes |
+| <a name="input_worker_subnets"></a> [worker\_subnets](#input\_worker\_subnets) | Subnet(s) to use for the worker | `list(string)` | n/a | yes |
 | <a name="input_worker_task_role_arn"></a> [worker\_task\_role\_arn](#input\_worker\_task\_role\_arn) | Optional task role ARN to pass to the worker. If not defined, a task role will be created | `string` | `null` | no |
-| <a name="input_worker_type"></a> [worker\_type](#input\_worker\_type) | Prefect Worker type that gets passed into the prefect worker start command | `string` | `"ecs"` | no |
-| <a name="input_worker_work_pool_name"></a> [worker\_work\_pool\_name](#input\_worker\_work\_pool\_name) | Work pool that the worker should listen to | `string` | n/a | yes |
+| <a name="input_worker_type"></a> [worker\_type](#input\_worker\_type) | Prefect worker type that gets passed into the Prefect worker start command | `string` | `"ecs"` | no |
+| <a name="input_worker_work_pool_name"></a> [worker\_work\_pool\_name](#input\_worker\_work\_pool\_name) | Work pool that the worker should poll | `string` | n/a | yes |
 
 ## Outputs
 

--- a/infra/amazon-ecs-worker/README.md
+++ b/infra/amazon-ecs-worker/README.md
@@ -93,6 +93,10 @@ No modules.
 | [aws_ecs_task_definition.prefect_worker_task_definition](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
 | [aws_iam_role.prefect_worker_execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.prefect_worker_task_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.logs_allow_create_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.ssm_allow_read_prefect_api_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy_attachment.prefect_worker_ecs_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_secretsmanager_secret.prefect_api_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret_version.prefect_api_key_version](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_security_group.prefect_worker](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |

--- a/infra/amazon-ecs-worker/README.md
+++ b/infra/amazon-ecs-worker/README.md
@@ -126,7 +126,7 @@ No modules.
 | <a name="input_worker_cpu"></a> [worker\_cpu](#input\_worker\_cpu) | CPU units to allocate to the worker | `number` | `1024` | no |
 | <a name="input_worker_desired_count"></a> [worker\_desired\_count](#input\_worker\_desired\_count) | Number of workers to run | `number` | `1` | no |
 | <a name="input_worker_extra_pip_packages"></a> [worker\_extra\_pip\_packages](#input\_worker\_extra\_pip\_packages) | Packages to install on the worker assuming image is based on prefecthq/prefect | `string` | `"prefect-aws s3fs"` | no |
-| <a name="input_worker_image"></a> [worker\_image](#input\_worker\_image) | Container image for the worker. This could be the name of an image in a public repo or an ECR ARN | `string` | `"prefecthq/prefect:2-python3.10"` | no |
+| <a name="input_worker_image"></a> [worker\_image](#input\_worker\_image) | Container image for the worker. This could be the name of an image in a public repo or an ECR ARN | `string` | `"prefecthq/prefect:3-python3.11"` | no |
 | <a name="input_worker_log_retention_in_days"></a> [worker\_log\_retention\_in\_days](#input\_worker\_log\_retention\_in\_days) | Number of days to retain worker logs for | `number` | `30` | no |
 | <a name="input_worker_memory"></a> [worker\_memory](#input\_worker\_memory) | Memory units to allocate to the worker | `number` | `2048` | no |
 | <a name="input_worker_subnets"></a> [worker\_subnets](#input\_worker\_subnets) | Subnets to place the worker in | `list(string)` | n/a | yes |

--- a/infra/amazon-ecs-worker/README.md
+++ b/infra/amazon-ecs-worker/README.md
@@ -1,0 +1,132 @@
+# Prefect 2 worker on ECS Fargate
+
+This recipe demonstrates how to deploy a Prefect 2 worker onto ECS Fargate using [Terraform](https://www.terraform.io/). It is intended to be used as a Terraform module as described in [Usage](#usage) below. It assumes you have Terraform installed, and was tested with Terraform `v1.4.6`.
+
+Note that flows will run inside the worker ECS task, as opposed to becoming their own ECS tasks.
+
+## Usage
+
+![image](https://github.com/PrefectHQ/prefect-recipes/assets/68969861/d148af90-58dd-4ce2-a160-e23fada6c895)
+
+
+To start with you will need your Prefect account ID, workspace ID, and API key. You will also need to pick one or more subnets that Fargate will launch into, as well as give your deployment a name.
+
+In order to avoid accidentally committing your API key, consider structuring your project as follows,
+
+```
+.
+├── main.tf
+├── terraform.tfvars
+└── variables.tf
+```
+
+```hcl
+// variables.tf
+variable prefect_api_key {}
+```
+
+```hcl
+// terraform.tfvars
+// Don't panic! This isn't a real API key
+prefect_api_key = "pnu_bcf655365883614d468990896264f6a30372"
+```
+
+```hcl
+// main.tf
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+// Don't panic! These values are just random uuid.uuid4()s
+module "prefect_ecs_worker" {
+  source = "github.com/PrefectHQ/prefect-recipes//devops/infrastructure-as-code/aws/tf-prefect2-ecs-worker"
+
+  worker_subnets        = [
+    "subnet-014aa5f348034e45b",
+    "subnet-df23ae9eab1f49af9"
+  ]
+  name                  = "dev"
+  prefect_account_id    = "6e02a1db-07de-4760-a15d-60d8fe0b04e1"
+  prefect_api_key       = var.prefect_api_key
+  prefect_workspace_id  = "54cdfc71-9f13-41ba-9492-e1cf24eed185"
+  worker_work_pool_name = "my-ecs-pool"
+  vpc_id                = "vpc-acfc2092275244ca8"
+}
+```
+
+Assuming the file structure above, you can run `terraform init` followed by `terraform apply` to create the resources. Check out the [Inputs](#inputs) section below for more options.
+
+## Reference
+
+The [terraform docs](https://terraform-docs.io/) below can be generated with the following command:
+
+```sh
+terraform-docs markdown table . --output-file README.md
+```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_log_group.prefect_worker_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_ecs_cluster.prefect_worker_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster) | resource |
+| [aws_ecs_cluster_capacity_providers.prefect_worker_cluster_capacity_providers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster_capacity_providers) | resource |
+| [aws_ecs_service.prefect_worker_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
+| [aws_ecs_task_definition.prefect_worker_task_definition](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
+| [aws_iam_role.prefect_worker_execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.prefect_worker_task_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_secretsmanager_secret.prefect_api_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret_version.prefect_api_key_version](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
+| [aws_security_group.prefect_worker](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group_rule.https_outbound](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_name"></a> [name](#input\_name) | Unique name for this worker deployment | `string` | n/a | yes |
+| <a name="input_prefect_account_id"></a> [prefect\_account\_id](#input\_prefect\_account\_id) | Prefect cloud account ID | `string` | n/a | yes |
+| <a name="input_prefect_api_key"></a> [prefect\_api\_key](#input\_prefect\_api\_key) | Prefect cloud API key | `string` | n/a | yes |
+| <a name="input_prefect_workspace_id"></a> [prefect\_workspace\_id](#input\_prefect\_workspace\_id) | Prefect cloud workspace ID | `string` | n/a | yes |
+| <a name="input_secrets_manager_recovery_in_days"></a> [secrets\_manager\_recovery\_in\_days](#input\_secrets\_manager\_recovery\_in\_days) | Deletion delay for AWS Secrets Manager upon resource destruction | `number` | `30` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID in which to create all resources | `string` | n/a | yes |
+| <a name="input_worker_cpu"></a> [worker\_cpu](#input\_worker\_cpu) | CPU units to allocate to the worker | `number` | `1024` | no |
+| <a name="input_worker_desired_count"></a> [worker\_desired\_count](#input\_worker\_desired\_count) | Number of workers to run | `number` | `1` | no |
+| <a name="input_worker_extra_pip_packages"></a> [worker\_extra\_pip\_packages](#input\_worker\_extra\_pip\_packages) | Packages to install on the worker assuming image is based on prefecthq/prefect | `string` | `"prefect-aws s3fs"` | no |
+| <a name="input_worker_image"></a> [worker\_image](#input\_worker\_image) | Container image for the worker. This could be the name of an image in a public repo or an ECR ARN | `string` | `"prefecthq/prefect:2-python3.10"` | no |
+| <a name="input_worker_log_retention_in_days"></a> [worker\_log\_retention\_in\_days](#input\_worker\_log\_retention\_in\_days) | Number of days to retain worker logs for | `number` | `30` | no |
+| <a name="input_worker_memory"></a> [worker\_memory](#input\_worker\_memory) | Memory units to allocate to the worker | `number` | `2048` | no |
+| <a name="input_worker_subnets"></a> [worker\_subnets](#input\_worker\_subnets) | Subnets to place the worker in | `list(string)` | n/a | yes |
+| <a name="input_worker_task_role_arn"></a> [worker\_task\_role\_arn](#input\_worker\_task\_role\_arn) | Optional task role ARN to pass to the worker. If not defined, a task role will be created | `string` | `null` | no |
+| <a name="input_worker_type"></a> [worker\_type](#input\_worker\_type) | Prefect Worker type that gets passed into the prefect worker start command | `string` | `"ecs"` | no |
+| <a name="input_worker_work_pool_name"></a> [worker\_work\_pool\_name](#input\_worker\_work\_pool\_name) | Work pool that the worker should listen to | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_prefect_worker_cluster_name"></a> [prefect\_worker\_cluster\_name](#output\_prefect\_worker\_cluster\_name) | n/a |
+| <a name="output_prefect_worker_execution_role_arn"></a> [prefect\_worker\_execution\_role\_arn](#output\_prefect\_worker\_execution\_role\_arn) | n/a |
+| <a name="output_prefect_worker_security_group"></a> [prefect\_worker\_security\_group](#output\_prefect\_worker\_security\_group) | n/a |
+| <a name="output_prefect_worker_service_id"></a> [prefect\_worker\_service\_id](#output\_prefect\_worker\_service\_id) | n/a |
+| <a name="output_prefect_worker_task_role_arn"></a> [prefect\_worker\_task\_role\_arn](#output\_prefect\_worker\_task\_role\_arn) | n/a |
+<!-- END_TF_DOCS -->

--- a/infra/amazon-ecs-worker/README.md
+++ b/infra/amazon-ecs-worker/README.md
@@ -64,6 +64,9 @@ module "prefect_ecs_worker" {
 
 Assuming the file structure above, you can run `terraform init` followed by `terraform apply` to create the resources. Check out the [Inputs](#inputs) section below for more options.
 
+Once complete, you will see a new work pool available in Prefect. You can then use this work pool for your deployments.
+See the [deployments documentation](https://docs.prefect.io/v3/deploy/index) for more information.
+
 ## Reference
 
 The [terraform docs](https://terraform-docs.io/) below can be generated with the following command:

--- a/infra/amazon-ecs-worker/README.md
+++ b/infra/amazon-ecs-worker/README.md
@@ -1,15 +1,22 @@
 # Prefect 2 worker on ECS Fargate
 
-This recipe demonstrates how to deploy a Prefect 2 worker onto ECS Fargate using [Terraform](https://www.terraform.io/). It is intended to be used as a Terraform module as described in [Usage](#usage) below. It assumes you have Terraform installed, and was tested with Terraform `v1.4.6`.
+This recipe demonstrates how to deploy a Prefect 3 worker onto ECS Fargate using [Terraform](https://www.terraform.io/). It is intended to be used as a Terraform module as described in [Usage](#usage) below. It assumes you have Terraform installed, and was tested with Terraform `v1.11`.
 
 Note that flows will run inside the worker ECS task, as opposed to becoming their own ECS tasks.
 
-## Usage
-
 ![image](https://github.com/PrefectHQ/prefect-recipes/assets/68969861/d148af90-58dd-4ce2-a160-e23fada6c895)
 
+## Requirements
 
-To start with you will need your Prefect account ID, workspace ID, and API key. You will also need to pick one or more subnets that Fargate will launch into, as well as give your deployment a name.
+To start, you will need:
+
+- Your Prefect account ID
+- Your Prefect workspace ID
+- Your Prefect API key
+- A subnet where Fargate will create ECS tasks
+- A name for your deployment
+
+## Usage
 
 In order to avoid accidentally committing your API key, consider structuring your project as follows,
 
@@ -40,7 +47,7 @@ provider "aws" {
 
 // Don't panic! These values are just random uuid.uuid4()s
 module "prefect_ecs_worker" {
-  source = "github.com/PrefectHQ/prefect-recipes//devops/infrastructure-as-code/aws/tf-prefect2-ecs-worker"
+  source = "github.com/PrefectHQ/examples/infra/amazon-ecs-worker"
 
   worker_subnets        = [
     "subnet-014aa5f348034e45b",

--- a/infra/amazon-ecs-worker/README.md
+++ b/infra/amazon-ecs-worker/README.md
@@ -110,7 +110,7 @@ No modules.
 | [aws_secretsmanager_secret.prefect_api_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret_version.prefect_api_key_version](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_security_group.prefect_worker](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
-| [aws_security_group_rule.https_outbound](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.network_outbound](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs

--- a/infra/amazon-ecs-worker/README.md
+++ b/infra/amazon-ecs-worker/README.md
@@ -76,7 +76,7 @@ terraform-docs markdown table . --output-file README.md
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.90.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
 
 ## Modules
 

--- a/infra/amazon-ecs-worker/README.md
+++ b/infra/amazon-ecs-worker/README.md
@@ -70,13 +70,13 @@ terraform-docs markdown table . --output-file README.md
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.90.1 |
 
 ## Modules
 

--- a/infra/amazon-ecs-worker/ecs.tf
+++ b/infra/amazon-ecs-worker/ecs.tf
@@ -1,0 +1,72 @@
+resource "aws_ecs_cluster" "prefect_worker_cluster" {
+  name = "prefect-worker-${var.name}"
+}
+
+resource "aws_ecs_cluster_capacity_providers" "prefect_worker_cluster_capacity_providers" {
+  cluster_name       = aws_ecs_cluster.prefect_worker_cluster.name
+  capacity_providers = ["FARGATE"]
+}
+
+resource "aws_ecs_task_definition" "prefect_worker_task_definition" {
+  family = "prefect-worker-${var.name}"
+  cpu    = var.worker_cpu
+  memory = var.worker_memory
+
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+
+  container_definitions = jsonencode([
+    {
+      name    = "prefect-worker-${var.name}"
+      image   = var.worker_image
+      command = ["prefect", "worker", "start", "-p", var.worker_work_pool_name, "--type", var.worker_type]
+      cpu     = var.worker_cpu
+      memory  = var.worker_memory
+      environment = [
+        {
+          name  = "PREFECT_API_URL"
+          value = "https://api.prefect.cloud/api/accounts/${var.prefect_account_id}/workspaces/${var.prefect_workspace_id}"
+        },
+        {
+          name  = "EXTRA_PIP_PACKAGES"
+          value = var.worker_extra_pip_packages
+        }
+      ]
+      secrets = [
+        {
+          name      = "PREFECT_API_KEY"
+          valueFrom = aws_secretsmanager_secret.prefect_api_key.arn
+        }
+      ]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.prefect_worker_log_group.name
+          awslogs-region        = data.aws_region.current.name
+          awslogs-stream-prefix = "prefect-worker-${var.name}"
+        }
+      }
+    }
+  ])
+  // Execution role allows ECS to create tasks and services
+  execution_role_arn = aws_iam_role.prefect_worker_execution_role.arn
+  // Task role allows tasks and services to access other AWS resources
+  // Use worker_task_role_arn if provided, otherwise populate with default
+  task_role_arn = var.worker_task_role_arn == null ? aws_iam_role.prefect_worker_task_role[0].arn : var.worker_task_role_arn
+}
+
+resource "aws_ecs_service" "prefect_worker_service" {
+  name          = "prefect-worker-${var.name}"
+  cluster       = aws_ecs_cluster.prefect_worker_cluster.id
+  desired_count = var.worker_desired_count
+  launch_type   = "FARGATE"
+
+  // Public IP required for pulling secrets and images
+  // https://aws.amazon.com/premiumsupport/knowledge-center/ecs-unable-to-pull-secrets/
+  network_configuration {
+    security_groups  = [aws_security_group.prefect_worker.id]
+    assign_public_ip = true
+    subnets          = var.worker_subnets
+  }
+  task_definition = aws_ecs_task_definition.prefect_worker_task_definition.arn
+}

--- a/infra/amazon-ecs-worker/ecs.tf
+++ b/infra/amazon-ecs-worker/ecs.tf
@@ -63,11 +63,9 @@ resource "aws_ecs_service" "prefect_worker_service" {
   desired_count = var.worker_desired_count
   launch_type   = "FARGATE"
 
-  // Public IP required for pulling secrets and images
-  // https://aws.amazon.com/premiumsupport/knowledge-center/ecs-unable-to-pull-secrets/
   network_configuration {
+    assign_public_ip = false
     security_groups  = [aws_security_group.prefect_worker.id]
-    assign_public_ip = true
     subnets          = var.worker_subnets
   }
 

--- a/infra/amazon-ecs-worker/ecs.tf
+++ b/infra/amazon-ecs-worker/ecs.tf
@@ -49,25 +49,24 @@ resource "aws_ecs_task_definition" "prefect_worker_task_definition" {
     }
   ])
 
-  // Execution role allows ECS to create tasks and services
+  // Execution role allows ECS to create tasks and services.
   execution_role_arn = aws_iam_role.prefect_worker_execution_role.arn
 
-  // Task role allows tasks and services to access other AWS resources
-  // Use worker_task_role_arn if provided, otherwise populate with default
+  // Task role allows tasks and services to access other AWS resources.
+  // Use worker_task_role_arn if provided, otherwise populate with default.
   task_role_arn = var.worker_task_role_arn == null ? aws_iam_role.prefect_worker_task_role[0].arn : var.worker_task_role_arn
 }
 
 resource "aws_ecs_service" "prefect_worker_service" {
-  name          = "prefect-worker-${var.name}"
-  cluster       = aws_ecs_cluster.prefect_worker_cluster.id
-  desired_count = var.worker_desired_count
-  launch_type   = "FARGATE"
+  name            = "prefect-worker-${var.name}"
+  cluster         = aws_ecs_cluster.prefect_worker_cluster.id
+  desired_count   = var.worker_desired_count
+  launch_type     = "FARGATE"
+  task_definition = aws_ecs_task_definition.prefect_worker_task_definition.arn
 
   network_configuration {
     assign_public_ip = false
     security_groups  = [aws_security_group.prefect_worker.id]
     subnets          = var.worker_subnets
   }
-
-  task_definition = aws_ecs_task_definition.prefect_worker_task_definition.arn
 }

--- a/infra/amazon-ecs-worker/ecs.tf
+++ b/infra/amazon-ecs-worker/ecs.tf
@@ -48,8 +48,10 @@ resource "aws_ecs_task_definition" "prefect_worker_task_definition" {
       }
     }
   ])
+
   // Execution role allows ECS to create tasks and services
   execution_role_arn = aws_iam_role.prefect_worker_execution_role.arn
+
   // Task role allows tasks and services to access other AWS resources
   // Use worker_task_role_arn if provided, otherwise populate with default
   task_role_arn = var.worker_task_role_arn == null ? aws_iam_role.prefect_worker_task_role[0].arn : var.worker_task_role_arn
@@ -68,5 +70,6 @@ resource "aws_ecs_service" "prefect_worker_service" {
     assign_public_ip = true
     subnets          = var.worker_subnets
   }
+
   task_definition = aws_ecs_task_definition.prefect_worker_task_definition.arn
 }

--- a/infra/amazon-ecs-worker/main.tf
+++ b/infra/amazon-ecs-worker/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/infra/amazon-ecs-worker/main.tf
+++ b/infra/amazon-ecs-worker/main.tf
@@ -102,7 +102,7 @@ resource "aws_iam_role" "prefect_worker_task_role" {
   })
 }
 
-resource "aws_iam_role_policy" "" {
+resource "aws_iam_role_policy" "prefect_worker_allow_ecs_task" {
   name  = "prefect-worker-allow-ecs-task-${var.name}"
   count = var.worker_task_role_arn == null ? 1 : 0
   role  = prefect_worker_task_role.id

--- a/infra/amazon-ecs-worker/main.tf
+++ b/infra/amazon-ecs-worker/main.tf
@@ -1,0 +1,130 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+
+// Region speficied in AWS provider
+data "aws_region" "current" {}
+
+resource "aws_secretsmanager_secret" "prefect_api_key" {
+  name                    = "prefect-api-key-${var.name}"
+  recovery_window_in_days = var.secrets_manager_recovery_in_days
+}
+
+resource "aws_secretsmanager_secret_version" "prefect_api_key_version" {
+  secret_id     = aws_secretsmanager_secret.prefect_api_key.id
+  secret_string = var.prefect_api_key
+}
+
+resource "aws_iam_role" "prefect_worker_execution_role" {
+  name = "prefect-worker-execution-role-${var.name}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      },
+    ]
+  })
+
+  inline_policy {
+    name = "ssm-allow-read-prefect-api-key-${var.name}"
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Action = [
+            "kms:Decrypt",
+            "secretsmanager:GetSecretValue",
+            "ssm:GetParameters"
+          ]
+          Effect = "Allow"
+          Resource = [
+            aws_secretsmanager_secret.prefect_api_key.arn
+          ]
+        }
+      ]
+    })
+  }
+  inline_policy {
+    name = "logs-allow-create-log-group-${var.name}"
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Action = [
+            "logs:CreateLogGroup",
+          ]
+          Effect   = "Allow"
+          Resource = "*"
+        }
+      ]
+    })
+  }
+  // AmazonECSTaskExecutionRolePolicy is an AWS managed role for creating ECS tasks and services
+  managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"]
+}
+
+resource "aws_iam_role" "prefect_worker_task_role" {
+  name  = "prefect-worker-task-role-${var.name}"
+  count = var.worker_task_role_arn == null ? 1 : 0
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      },
+    ]
+  })
+
+  inline_policy {
+    name = "prefect-worker-allow-ecs-task-${var.name}"
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Action = [
+            "ec2:DescribeSubnets",
+            "ec2:DescribeVpcs",
+            "ecr:BatchCheckLayerAvailability",
+            "ecr:BatchGetImage",
+            "ecr:GetAuthorizationToken",
+            "ecr:GetDownloadUrlForLayer",
+            "ecs:DeregisterTaskDefinition",
+            "ecs:DescribeTaskDefinition",
+            "ecs:DescribeTasks",
+            "ecs:RegisterTaskDefinition",
+            "ecs:RunTask",
+            "ecs:StopTask",
+            "iam:PassRole",
+            "logs:CreateLogGroup",
+            "logs:CreateLogStream",
+            "logs:GetLogEvents",
+            "logs:PutLogEvents"
+          ]
+          Effect   = "Allow"
+          Resource = "*"
+        }
+      ]
+    })
+  }
+}
+
+resource "aws_cloudwatch_log_group" "prefect_worker_log_group" {
+  name              = "prefect-worker-log-group-${var.name}"
+  retention_in_days = var.worker_log_retention_in_days
+}

--- a/infra/amazon-ecs-worker/main.tf
+++ b/infra/amazon-ecs-worker/main.tf
@@ -35,9 +35,13 @@ resource "aws_iam_role" "prefect_worker_execution_role" {
       },
     ]
   })
+}
+
+resource "aws_iam_role_policy_attachment" "prefect_worker_ecs_policy" {
+  role = aws_iam_role.prefect_worker_execution_role.name
 
   // AmazonECSTaskExecutionRolePolicy is an AWS managed role for creating ECS tasks and services
-  managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"]
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
 
 resource "aws_iam_role_policy" "ssm_allow_read_prefect_api_key" {

--- a/infra/amazon-ecs-worker/main.tf
+++ b/infra/amazon-ecs-worker/main.tf
@@ -105,7 +105,7 @@ resource "aws_iam_role" "prefect_worker_task_role" {
 resource "aws_iam_role_policy" "prefect_worker_allow_ecs_task" {
   name  = "prefect-worker-allow-ecs-task-${var.name}"
   count = var.worker_task_role_arn == null ? 1 : 0
-  role  = prefect_worker_task_role.id
+  role  = aws_iam_role.prefect_worker_task_role[0].id
 
   policy = jsonencode({
     Version = "2012-10-17"

--- a/infra/amazon-ecs-worker/main.tf
+++ b/infra/amazon-ecs-worker/main.tf
@@ -7,7 +7,7 @@ terraform {
   }
 }
 
-// Region speficied in AWS provider
+// Region specified in AWS provider
 data "aws_region" "current" {}
 
 resource "aws_secretsmanager_secret" "prefect_api_key" {

--- a/infra/amazon-ecs-worker/network.tf
+++ b/infra/amazon-ecs-worker/network.tf
@@ -4,17 +4,17 @@ resource "aws_security_group" "prefect_worker" {
   vpc_id      = var.vpc_id
 }
 
-resource "aws_security_group_rule" "https_outbound" {
+resource "aws_security_group_rule" "network_outbound" {
   // S3 Gateway interfaces are implemented at the routing level which means we
   // can avoid the metered billing of a VPC endpoint interface by allowing
   // outbound traffic to the public IP ranges, which will be routed through
   // the Gateway interface:
   // https://docs.aws.amazon.com/AmazonS3/latest/userguide/privatelink-interface-endpoints.html
-  description       = "HTTPS outbound"
+  description       = "Security group rule for Prefect Server running in Fargate."
   type              = "egress"
   security_group_id = aws_security_group.prefect_worker.id
-  from_port         = 443
-  to_port           = 443
-  protocol          = "tcp"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "all"
   cidr_blocks       = ["0.0.0.0/0"]
 }

--- a/infra/amazon-ecs-worker/network.tf
+++ b/infra/amazon-ecs-worker/network.tf
@@ -1,0 +1,20 @@
+resource "aws_security_group" "prefect_worker" {
+  name        = "prefect-worker-sg-${var.name}"
+  description = "ECS Prefect worker"
+  vpc_id      = var.vpc_id
+}
+
+resource "aws_security_group_rule" "https_outbound" {
+  // S3 Gateway interfaces are implemented at the routing level which means we
+  // can avoid the metered billing of a VPC endpoint interface by allowing
+  // outbound traffic to the public IP ranges, which will be routed through
+  // the Gateway interface:
+  // https://docs.aws.amazon.com/AmazonS3/latest/userguide/privatelink-interface-endpoints.html
+  description       = "HTTPS outbound"
+  type              = "egress"
+  security_group_id = aws_security_group.prefect_worker.id
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+}

--- a/infra/amazon-ecs-worker/outputs.tf
+++ b/infra/amazon-ecs-worker/outputs.tf
@@ -1,0 +1,19 @@
+output "prefect_worker_service_id" {
+  value = aws_ecs_service.prefect_worker_service.id
+}
+
+output "prefect_worker_execution_role_arn" {
+  value = aws_iam_role.prefect_worker_execution_role.arn
+}
+
+output "prefect_worker_task_role_arn" {
+  value = var.worker_task_role_arn == null ? aws_iam_role.prefect_worker_task_role[0].arn : var.worker_task_role_arn
+}
+
+output "prefect_worker_security_group" {
+  value = aws_security_group.prefect_worker.id
+}
+
+output "prefect_worker_cluster_name" {
+  value = aws_ecs_cluster.prefect_worker_cluster.name
+}

--- a/infra/amazon-ecs-worker/variables.tf
+++ b/infra/amazon-ecs-worker/variables.tf
@@ -1,0 +1,89 @@
+variable "worker_cpu" {
+  description = "CPU units to allocate to the worker"
+  default     = 1024
+  type        = number
+}
+
+variable "worker_desired_count" {
+  description = "Number of workers to run"
+  default     = 1
+  type        = number
+}
+
+variable "worker_extra_pip_packages" {
+  description = "Packages to install on the worker assuming image is based on prefecthq/prefect"
+  default     = "prefect-aws s3fs"
+  type        = string
+}
+
+variable "worker_image" {
+  description = "Container image for the worker. This could be the name of an image in a public repo or an ECR ARN"
+  default     = "prefecthq/prefect:2-python3.10"
+  type        = string
+}
+
+variable "worker_log_retention_in_days" {
+  description = "Number of days to retain worker logs for"
+  default     = 30
+  type        = number
+}
+
+variable "worker_memory" {
+  description = "Memory units to allocate to the worker"
+  default     = 2048
+  type        = number
+}
+
+variable "worker_work_pool_name" {
+  description = "Work pool that the worker should listen to"
+  type        = string
+}
+
+variable "worker_subnets" {
+  description = "Subnets to place the worker in"
+  type        = list(string)
+}
+
+variable "worker_task_role_arn" {
+  description = "Optional task role ARN to pass to the worker. If not defined, a task role will be created"
+  default     = null
+  type        = string
+}
+
+variable "name" {
+  description = "Unique name for this worker deployment"
+  type        = string
+}
+
+variable "prefect_account_id" {
+  description = "Prefect cloud account ID"
+  type        = string
+}
+
+variable "prefect_workspace_id" {
+  description = "Prefect cloud workspace ID"
+  type        = string
+}
+
+variable "prefect_api_key" {
+  description = "Prefect cloud API key"
+  type        = string
+  sensitive   = true
+}
+
+variable "vpc_id" {
+  description = "VPC ID in which to create all resources"
+  type        = string
+}
+
+variable "secrets_manager_recovery_in_days" {
+  type        = number
+  default     = 30
+  description = "Deletion delay for AWS Secrets Manager upon resource destruction"
+}
+
+variable "worker_type" {
+  type        = string
+  default     = "ecs"
+  description = "Prefect Worker type that gets passed into the prefect worker start command"
+}

--- a/infra/amazon-ecs-worker/variables.tf
+++ b/infra/amazon-ecs-worker/variables.tf
@@ -18,7 +18,7 @@ variable "worker_extra_pip_packages" {
 
 variable "worker_image" {
   description = "Container image for the worker. This could be the name of an image in a public repo or an ECR ARN"
-  default     = "prefecthq/prefect:2-python3.10"
+  default     = "prefecthq/prefect:3-python3.11"
   type        = string
 }
 

--- a/infra/amazon-ecs-worker/variables.tf
+++ b/infra/amazon-ecs-worker/variables.tf
@@ -23,7 +23,7 @@ variable "worker_image" {
 }
 
 variable "worker_log_retention_in_days" {
-  description = "Number of days to retain worker logs for"
+  description = "Number of days to retain worker logs"
   default     = 30
   type        = number
 }
@@ -35,12 +35,12 @@ variable "worker_memory" {
 }
 
 variable "worker_work_pool_name" {
-  description = "Work pool that the worker should listen to"
+  description = "Work pool that the worker should poll"
   type        = string
 }
 
 variable "worker_subnets" {
-  description = "Subnets to place the worker in"
+  description = "Subnet(s) to use for the worker"
   type        = list(string)
 }
 
@@ -56,17 +56,17 @@ variable "name" {
 }
 
 variable "prefect_account_id" {
-  description = "Prefect cloud account ID"
+  description = "Prefect Cloud account ID"
   type        = string
 }
 
 variable "prefect_workspace_id" {
-  description = "Prefect cloud workspace ID"
+  description = "Prefect Cloud workspace ID"
   type        = string
 }
 
 variable "prefect_api_key" {
-  description = "Prefect cloud API key"
+  description = "Prefect Cloud API key"
   type        = string
   sensitive   = true
 }
@@ -85,5 +85,5 @@ variable "secrets_manager_recovery_in_days" {
 variable "worker_type" {
   type        = string
   default     = "ecs"
-  description = "Prefect Worker type that gets passed into the prefect worker start command"
+  description = "Prefect worker type that gets passed into the Prefect worker start command"
 }


### PR DESCRIPTION
## Summary

Adds a modernized version of our [previous ECS worker module](https://github.com/PrefectHQ/prefect-recipes/tree/main/devops/infrastructure-as-code/aws/tf-prefect2-ecs-worker).

Closes https://linear.app/prefect/issue/PLA-1072/create-opinionated-terraform-module-that-deploys-an-aws-ecs-cluster

Related to https://github.com/PrefectHQ/examples/issues/11

## To do
- [x] Copy over existing, archived module
- [x] Update module to current specs/standards
- [ ] Test the module

## Acceptance criteria
- [x] Takes in minimal input / configuration from the user (not intended to be highly configurable/used in production, but a good starting point)
- [x] Comprehensive readme / how to use / deploy
- [ ] Referenced in our docs